### PR TITLE
Avoid backuppc start failure

### DIFF
--- a/startscript.sh
+++ b/startscript.sh
@@ -26,6 +26,7 @@ fi
 echo "Setting permissions"
 chown -R backuppc:www-data $PERSISTENT_CONFIG
 chown -R backuppc:backuppc $PERSISTENT_DATA
+chmod 775 $PERSISTENT_CONFIG $PERSISTENT_DATA
 chmod -R 0600 $PERSISTENT_DATA/.ssh/*
 
 # Start supervisord


### PR DESCRIPTION
When using Docker and mounting volumes, $PERSISTENT_CONFIG $PERSISTENT_DATA folders do not get the correct permissions which avoid backuppc to start. That's why changing permission allow it.