### PR TITLE
Add RESET_PERMISSIONS option to avoid long run reset at any boot #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV TMP_DATA /backuppc_initial_data
 ENV PERSISTENT_CONFIG /etc/backuppc
 ENV PERSISTENT_DATA /var/lib/backuppc
 ENV STARTSCRIPT /usr/local/bin/dockerstart.sh
+ENV RESET_PERMISSIONS true
 
 ADD startscript.sh $STARTSCRIPT
 
@@ -45,4 +46,4 @@ EXPOSE 80
 VOLUME $PERSISTENT_DATA
 VOLUME $PERSISTENT_CONFIG
 
-cmd $STARTSCRIPT 
+cmd $STARTSCRIPT

--- a/startscript.sh
+++ b/startscript.sh
@@ -24,10 +24,15 @@ fi
 
 # Set proper permissions
 echo "Setting permissions"
-chown -R backuppc:www-data $PERSISTENT_CONFIG
-chown -R backuppc:backuppc $PERSISTENT_DATA
-chmod 775 $PERSISTENT_CONFIG $PERSISTENT_DATA
-chmod -R 0600 $PERSISTENT_DATA/.ssh/*
+if [ $RESET_PERMISSIONS == 'true' ] ; then
+  chown -R backuppc:www-data $PERSISTENT_CONFIG
+  chown -R backuppc:backuppc $PERSISTENT_DATA
+  chmod 775 $PERSISTENT_CONFIG $PERSISTENT_DATA
+  if [ ! -d $PERSISTENT_DATA/.ssh ] ; then
+    mkdir -p $PERSISTENT_DATA/.ssh
+  fi
+  chmod -R 0600 $PERSISTENT_DATA/.ssh/*
+fi
 
 # Start supervisord
 echo "Starting supervisord"


### PR DESCRIPTION
Avoid long running permission reset on container startup by adding an option:
docker run -e RESET_PERMISSIONS=false ...